### PR TITLE
.Xlsx feature

### DIFF
--- a/airbyte-integrations/connectors/source-http-request/setup.py
+++ b/airbyte-integrations/connectors/source-http-request/setup.py
@@ -28,6 +28,7 @@ from setuptools import find_packages, setup
 MAIN_REQUIREMENTS = [
     "airbyte-cdk",
     "pandas",
+    "openpyxl",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
+++ b/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
@@ -181,7 +181,7 @@ class HttpRequest(HttpStream):
                             yield value
         elif self._response_format == "xlsx":
             pd.read_excel(response.content,  dtype=str, index_col=None).to_csv('temp.csv', encoding='utf-8', index=False)
-            data = csv.DictReader(pd.read_csv('./temp.csv', dtype=str, index_col=None).to_string().splitlines())
+            data = csv.DictReader(pd.read_csv('./temp.csv', dtype=str, delimiter=self._response_delimiter).to_string().splitlines(), dialect='excel')
             yield from data
         else:
             raise Exception("Invalid response format")

--- a/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
+++ b/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
@@ -134,6 +134,11 @@ class HttpRequest(HttpStream):
                         my_dict = [root[i][0] for i in sorted(root.keys())][0]
                         df = pd.DataFrame.from_dict([my_dict])
                 headers = df.columns.tolist()
+            elif self._response_format == "xlsx":
+                data_xls = pd.read_excel(resp.content,  dtype=str, index_col=None)
+                data_xls.to_csv('temp.csv', encoding='utf-8', index=False)
+                df = pd.read_csv('./temp.csv', dtype=str, index_col=None)
+                headers = df.columns.tolist()
 
         properties = {}
         for header in headers:
@@ -174,6 +179,10 @@ class HttpRequest(HttpStream):
                     for _, values in root[self._json_field].items():
                         for value in values:
                             yield value
+        elif self._response_format == "xlsx":
+            pd.read_excel(response.content,  dtype=str, index_col=None).to_csv('temp.csv', encoding='utf-8', index=False)
+            data = csv.DictReader(pd.read_csv('./temp.csv', dtype=str, index_col=None).to_string().splitlines())
+            yield from data
         else:
             raise Exception("Invalid response format")
 

--- a/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
+++ b/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
@@ -135,9 +135,7 @@ class HttpRequest(HttpStream):
                         df = pd.DataFrame.from_dict([my_dict])
                 headers = df.columns.tolist()
             elif self._response_format == "xlsx":
-                data_xls = pd.read_excel(resp.content,  dtype=str, index_col=None)
-                data_xls.to_csv('temp.csv', encoding='utf-8', index=False)
-                df = pd.read_csv('./temp.csv', dtype=str, index_col=None)
+                df = pd.read_excel(resp.content,  dtype=str, index_col=None)
                 headers = df.columns.tolist()
 
         properties = {}

--- a/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
+++ b/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
@@ -179,7 +179,7 @@ class HttpRequest(HttpStream):
                             yield value
         elif self._response_format == "xlsx":
             pd.read_excel(response.content,  dtype=str, index_col=None).to_csv('temp.csv', encoding='utf-8', index=False)
-            data = csv.DictReader(pd.read_csv('./temp.csv', dtype=str, delimiter=self._response_delimiter).to_string().splitlines(), dialect='excel')
+            data = csv.DictReader(pd.read_csv('./temp.csv', dtype=str, delimiter=self._response_delimiter).to_string(index=False).splitlines(), dialect='excel')
             yield from data
         else:
             raise Exception("Invalid response format")

--- a/airbyte-integrations/connectors/source-http-request/source_http_request/spec.json
+++ b/airbyte-integrations/connectors/source-http-request/source_http_request/spec.json
@@ -35,7 +35,7 @@
       "response_format": {
         "description": "the format of the response",
         "type": "string",
-        "enum": ["csv", "json"]
+        "enum": ["csv", "json", "xlsx"]
       },
       "response_delimiter": {
         "description": "the response delimiter when the response format is csv",


### PR DESCRIPTION
## What

This PR enables support for .xlsx response.

### Before test
Don't forget to build the connector
```bash
docker build . -t airbyte/source-http-request:0.1.0
```

To test, create a data source like this using streams collector: 

```json
{
  "configurations": {
    "url": "https://cesartc.s3.us-east-2.amazonaws.com/infdiario.xlsx",
    "http_method": "GET",
    "response_format": "xlsx",
    "response_delimiter": ";"
  },
    "description": "CVM AS SOURCE NEW2",
    "name": "API CVM xlsx",
    "source_definition_id": 2,
    "user_id": "{{user_id}}"
  }
```

Connect to the data source with:
```json
{
  "source_definition_id": "2",
	"airbyte_source_id": "ef040bba-7958-4f03-8ed5-735be7eca3e6",
	"source_id": "d854f073-6298-4fe5-8e4c-826e05334f15",
  	"datasets": {
		"streams": [
			{
              "name": "http_request",
              "description": "stream_1",
              "properties": [
                    {
                        "name": "data",
                        "description": "index",
                        "type": "number"
                    },
                    {
                          "name": "HEAD_ONE",
                        "description": "filed_2",
                        "type": "string"
                    },
                    {
                        "name": "HEAD_THREE",
                        "description": "filed_2",
                        "type": "string"
                    }
              ]
      		}
		]
	},
	"schedule_type": "minutes",
	"schedule_unit": 4
}
```
